### PR TITLE
Implement basic live attendance feature

### DIFF
--- a/src/Controller/Front/LiveAttendanceController.php
+++ b/src/Controller/Front/LiveAttendanceController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KejawenLab\Application\SemartHris\Controller\Front;
+
+use KejawenLab\Application\SemartHris\Entity\LiveAttendance;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route("/attendance/live")
+ */
+class LiveAttendanceController extends Controller
+{
+    /**
+     * @Route("/", name="live_attendance")
+     */
+    public function index(): Response
+    {
+        return $this->render('app/attendance/live.html.twig');
+    }
+
+    /**
+     * @Route("/submit", name="submit_live_attendance", methods={"POST"})
+     */
+    public function submit(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!$data || !isset($data['image'])) {
+            return new JsonResponse(['status' => 'error'], 400);
+        }
+
+        $image = preg_replace('#^data:image/\w+;base64,#i', '', $data['image']);
+        $image = base64_decode($image);
+        $fileName = sprintf('%s_%s.png', $this->getUser()->getId(), (new \DateTime())->format('YmdHis'));
+        $dir = $this->getParameter('kernel.project_dir').'/public/files/live';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents(sprintf('%s/%s', $dir, $fileName), $image);
+
+        $live = new LiveAttendance();
+        $live->setEmployee($this->getUser());
+        $live->setCapturedAt(new \DateTime());
+        $live->setType($data['type'] ?? 'in');
+        $live->setPhotoPath('/files/live/'.$fileName);
+        $live->setLatitude($data['lat'] ?? 0);
+        $live->setLongitude($data['lon'] ?? 0);
+
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($live);
+        $em->flush();
+
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/src/Entity/LiveAttendance.php
+++ b/src/Entity/LiveAttendance.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KejawenLab\Application\SemartHris\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Blameable\Traits\BlameableEntity;
+use Gedmo\SoftDeleteable\Traits\SoftDeleteableEntity;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+use KejawenLab\Application\SemartHris\Component\Employee\Model\EmployeeInterface;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="live_attendances")
+ */
+class LiveAttendance
+{
+    use BlameableEntity;
+    use SoftDeleteableEntity;
+    use TimestampableEntity;
+
+    /**
+     * @Groups({"read"})
+     *
+     * @ORM\Id()
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Ramsey\\Uuid\\Doctrine\\UuidGenerator")
+     */
+    private $id;
+
+    /**
+     * @Groups({"write", "read"})
+     *
+     * @ORM\ManyToOne(targetEntity="KejawenLab\\Application\\SemartHris\\Entity\\Employee", fetch="EAGER")
+     * @ORM\JoinColumn(name="employee_id", referencedColumnName="id")
+     */
+    private $employee;
+
+    /**
+     * @Groups({"read", "write"})
+     *
+     * @ORM\Column(type="datetime")
+     */
+    private $capturedAt;
+
+    /**
+     * @Groups({"read", "write"})
+     *
+     * @ORM\Column(type="string")
+     */
+    private $type;
+
+    /**
+     * @Groups({"read", "write"})
+     *
+     * @ORM\Column(type="string")
+     */
+    private $photoPath;
+
+    /**
+     * @Groups({"read", "write"})
+     *
+     * @ORM\Column(type="decimal", precision=10, scale=7)
+     */
+    private $latitude;
+
+    /**
+     * @Groups({"read", "write"})
+     *
+     * @ORM\Column(type="decimal", precision=10, scale=7)
+     */
+    private $longitude;
+
+    public function getId(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function getEmployee(): ?EmployeeInterface
+    {
+        return $this->employee;
+    }
+
+    public function setEmployee(?EmployeeInterface $employee): void
+    {
+        $this->employee = $employee;
+    }
+
+    public function getCapturedAt(): ?\DateTimeInterface
+    {
+        return $this->capturedAt;
+    }
+
+    public function setCapturedAt(?\DateTimeInterface $capturedAt): void
+    {
+        $this->capturedAt = $capturedAt;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getPhotoPath(): ?string
+    {
+        return $this->photoPath;
+    }
+
+    public function setPhotoPath(?string $photoPath): void
+    {
+        $this->photoPath = $photoPath;
+    }
+
+    public function getLatitude(): ?float
+    {
+        return $this->latitude;
+    }
+
+    public function setLatitude(?float $latitude): void
+    {
+        $this->latitude = $latitude;
+    }
+
+    public function getLongitude(): ?float
+    {
+        return $this->longitude;
+    }
+
+    public function setLongitude(?float $longitude): void
+    {
+        $this->longitude = $longitude;
+    }
+}

--- a/templates/app/attendance/live.html.twig
+++ b/templates/app/attendance/live.html.twig
@@ -1,0 +1,45 @@
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Live Attendance</title>
+        <style>
+            video, canvas { border:1px solid #ccc; }
+        </style>
+    </head>
+    <body>
+        <h2>Live Attendance</h2>
+        <video id="video" width="320" height="240" autoplay></video>
+        <canvas id="canvas" width="320" height="240" style="display:none"></canvas>
+        <div>
+            <select id="type">
+                <option value="in">Check In</option>
+                <option value="out">Check Out</option>
+            </select>
+            <button id="capture">Capture</button>
+        </div>
+        <script>
+            const video = document.getElementById('video');
+            navigator.mediaDevices.getUserMedia({video: true}).then(stream => {
+                video.srcObject = stream;
+            }).catch(e => console.error(e));
+
+            document.getElementById('capture').addEventListener('click', () => {
+                navigator.geolocation.getCurrentPosition(pos => {
+                    const canvas = document.getElementById('canvas');
+                    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+                    const data = canvas.toDataURL('image/png');
+                    fetch('{{ path('submit_live_attendance') }}', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({
+                            image: data,
+                            lat: pos.coords.latitude,
+                            lon: pos.coords.longitude,
+                            type: document.getElementById('type').value
+                        })
+                    }).then(() => alert('submitted')).catch(err => alert('error'));
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal LiveAttendance entity
- add controller and template for capturing camera image and location
- save captured data as new LiveAttendance record

## Testing
- `php -l src/Entity/LiveAttendance.php`
- `php -l src/Controller/Front/LiveAttendanceController.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685754e8c190832ba76ae5eff8cd0974